### PR TITLE
Fixed json error and variable reference warnings

### DIFF
--- a/aaindex/__init__.py
+++ b/aaindex/__init__.py
@@ -4,7 +4,7 @@ from .aaindex1 import *
 
 #aaindex software metadata
 __name__ = "aaindex"
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __description__ = "A lightweight Python software package for accessing the data in the various AAIndex databases, which represent the physiochemical, biochemical and structural properties of amino acids as numerical indices."
 __author__ = 'AJ McKenna: https://github.com/amckenna41'
 __authorEmail__ = 'amckenna41@qub.ac.uk'

--- a/aaindex/aaindex1.py
+++ b/aaindex/aaindex1.py
@@ -99,10 +99,14 @@ class AAIndex1():
         #get dict of categories
         self.categories = self.get_all_categories()
 
-        #if parsed json of AAindex (aaindex1.json) already in file then read it and return 
-        if (os.path.isfile(os.path.join(self.aaindex_module_path, self.data_dir, self.aaindex_filename + '.json'))):
-            with open(os.path.join(self.aaindex_module_path, self.data_dir, self.aaindex_filename + '.json')) as aai_json:
-                self.aaindex_json = json.load(aai_json)
+        #if parsed json of AAindex (aaindex1.json) already in file then read it and return
+        aaindex_json_file = os.path.join(self.aaindex_module_path, self.data_dir, self.aaindex_filename + '.json')
+        if os.path.isfile(aaindex_json_file):
+            try:
+                with open(aaindex_json_file) as aai_json:
+                    self.aaindex_json = json.load(aai_json)
+            except (IOError, json.JSONDecodeError):  # unblocking import for corrupted local json file
+                self.aaindex_json = self.parse_aaindex()
         else:
             #parse AAindex database file into JSON format
             self.aaindex_json = self.parse_aaindex()
@@ -139,16 +143,16 @@ class AAIndex1():
                          "I":[]}
 
         #open AAi file for reading and parsing, by default it should be stored in self.data_dir
+        lines = [""]
         try:
             tmp_filepath = os.path.join(self.aaindex_module_path, self.data_dir, self.aaindex_filename)
             f = open(tmp_filepath,'r')
+            # read lines of file
+            lines = f.readlines()
+            f.close()
         except IOError:
             print('Error opening AAindex1 file, check file is in filepath: {}.'.format(
                     os.path.join(self.aaindex_module_path, self.data_dir, self.aaindex_filename)))
-
-        #read lines of file
-        lines = f.readlines()
-        f.close()
 
         #pattern that seperates each AAi record
         clean_up_pattern = re.compile("\"")
@@ -289,6 +293,7 @@ class AAIndex1():
                 f = open((os.path.join(self.aaindex_module_path, self.data_dir, aaindex_category_file)),'r')
             except IOError:
                 print('Error opening AAindex1 category file: {}.'.format(os.path.join(self.aaindex_module_path, self.data_dir, aaindex_category_file)))
+                raise
 
         #get total number of lines in file
         # total_lines = len(f.readlines(  ))


### PR DESCRIPTION
In case of corrupted aaindex download to the data-directory (such as happened in my case for aaindex1) `import aaindex` failed with a `json.decoder.JSONDecodeError`. Usage is prevented in such case.
With this fix, parsing errors (and in addition IOErrors) are caught, resulting in a normal loading of the package.

I also fixed two "might be referenced before usage" warnings in case of IOErrors reading input files.

Updated package version.